### PR TITLE
minor bug fix

### DIFF
--- a/shyaml
+++ b/shyaml
@@ -382,7 +382,7 @@ def main(args):  ## pylint: disable=too-many-branches
             die("%s does not support %r type. "
                 "Please provide or select a struct." % (action, tvalue))
     else:
-        die("Invalid argument.\n%s" % usage)
+        die("Invalid argument.\n%s" % USAGE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This is a very minor bugfix -- feel free to reject.


minor change to line 385 -- upon unsuccessful exit, program now replies: 
```
Error: Invalid argument.
Usage:

    shyaml (-h|--help)
    shyaml ACTION KEY [DEFAULT]
```

Previously: 
```
Traceback (most recent call last):
  File "/usr/local/bin/shyaml", line 389, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/local/bin/shyaml", line 385, in main
    die("Invalid argument.\n%s" % usage)
NameError: global name 'usage' is not defined
```