### PR TITLE
Add command to get length of a sequence or dict

### DIFF
--- a/shyaml
+++ b/shyaml
@@ -42,6 +42,10 @@ Options:
 
                 get-values{,-0}   ## return list of YAML
 
+              This ACTION applies to 'sequence' and 'struct' YAML type:
+
+                get-length        ## return length of the list of YAML
+
               These ACTION applies to 'struct' YAML type:
 
                 keys{,-0}         ## return list of YAML
@@ -397,6 +401,11 @@ def main(args):  ## pylint: disable=too-many-branches
                 % (action, tvalue))
     elif action == "get-type":
         print(tvalue)
+    elif action == "get-length":
+        if isinstance(value, dict):
+            stdout("%d" % len(value))
+        elif isinstance(value, list):
+            stdout("%d" % len(value))
     elif action in ("keys", "keys-0",
                     "values", "values-0",
                     "key-values", "key-values-0"):


### PR DESCRIPTION
I'm writing a bash shell script around shyaml and would like to be able to iterate over lists of dicts.  Being able to query their length first is advantageous.
