### PR TITLE
Drop Python 2 support

### DIFF
--- a/shyaml.py
+++ b/shyaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 YAML for command line.
 """


### PR DESCRIPTION
On Debian stable
```
$ /usr/bin/env python
/usr/bin/env: ‘python’: No such file or directory
```

Python 2 was EOL-ed almost 3 years ago
https://www.python.org/doc/sunset-python-2/

What do you think?
