### PR TITLE
drop d2to1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,16 @@
 [metadata]
 name = %%name%%
 version = %%version%%
-summary = %%description%%
-description-file =
-    README.rst
-    CHANGELOG.rst
+description = %%description%%
+long_description = file: README.rst, CHANGELOG.rst
 license_file = LICENSE
-requires-dist =
-    pyyaml
 
 ## sdist info
 author = %%author%%
 author_email = %%email%%
-home_page = http://github.com/0k/%%name%%
+url = http://github.com/0k/%%name%%
 license = BSD 3-Clause License
-classifier =
+classifiers =
     Programming Language :: Python
     Environment :: Console
     Intended Audience :: Developers
@@ -32,34 +28,22 @@ classifier =
     Programming Language :: Python :: 3.7
 
 
-[backwards_compat]
+[options]
 ## without this ``pip uninstall`` fails on recent version of setuptools
 ## (tested failing with setuptools 34.3.3, working with setuptools 9.1)
-zip-safe = False
-
+zip_safe = False
+install_requires =
+    pyyaml
 
 [bdist_wheel]
 universal = 1
-
-
-[files]
-extra_files =
-    README.rst
-    CHANGELOG.rst
-    setup.py
-## Note: d2to1 maps ``setup.py``'s ``py_modules`` to ``modules`` here.
-## This is required for single-file module, this allows the ``entry_point``
-## to reference ``shyaml``. Besides, this is needed also for direct python
-## API usage.
-modules =
-    shyaml
 
 ## We can't use scripts to share these simply as extension managed ``.py``
 ## is not correctly handled for both windows and linux to be happy.
 # scripts =
 #     shyaml
 
-[entry_points]
+[options.entry_points]
 console_scripts =
     ## will generate correct files with adequate extenstion in windows
     ## and linux, contrary to 'scripts'. Note that it requires 'shyaml'

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,7 @@ if "%%short-version%%".startswith("%%"):
 ##
 
 setup(
-    setup_requires=['d2to1'],
     extras_require={'test': [
         "docshtest==0.0.3",
         ]},
-    d2to1=True
 )


### PR DESCRIPTION
broken on modern setuptools:

```console
$ pip3 install --no-binary=:all: shyaml
...
× Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [33 lines of output]
      Traceback (most recent call last):
      ...
        File "/private/var/folders/1r/p5nhsx151fd7j63p9r1zz4kw0000gn/T/pip-build-env-xrqb__gx/normal/lib/python3.11/site-packages/d2to1/core.py", line 30, in d2to1
          from setuptools.dist import _get_unpatched
      ImportError: cannot import name '_get_unpatched' from 'setuptools.dist' (/private/var/folders/1r/p5nhsx151fd7j63p9r1zz4kw0000gn/T/pip-build-env-xrqb__gx/overlay/lib/python3.11/site-packages/setuptools/dist.py)
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```